### PR TITLE
Handle -h, --help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,65 @@
 name = "cargo-fmt"
 version = "0.1.0"
 dependencies = [
+ "docopt 0.6.75 (registry+https://github.com/rust-lang/crates.io-index)",
  "walker 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "aho-corasick"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docopt"
+version = "0.6.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ Allows `rustfmt` to be called through `cargo`
 
 [dependencies]
 walker = "^1.0.0"
+docopt = "0.6.75"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,10 @@ use std::process::Command;
 use std::env;
 use std::path::Path;
 use walker::Walker;
+use docopt::Docopt;
 
 extern crate walker;
+extern crate docopt;
 
 fn fmt(path: &Path, cwd: &Path) {
     Command::new("rustfmt")
@@ -14,7 +16,22 @@ fn fmt(path: &Path, cwd: &Path) {
         .unwrap_or_else(|e| panic!("failed to execute rustfmt: {:#?}", e));
 }
 
+const USAGE: &'static str = "
+Format all Rust source files in the project with rustfmt
+
+Usage:
+    cargo fmt [options]
+
+Options:
+    -h, --help  Print this message
+
+The current implementation formats all .rs files in
+the current directory, recursively.
+";
+
 fn main() {
+    let opts = Docopt::new(USAGE).unwrap();
+    opts.parse().unwrap_or_else(|e| e.exit());
     let cwd = env::current_dir().unwrap();
     match Walker::new(&cwd) {
         Ok(iter) => {


### PR DESCRIPTION
When the user does either of:
    - `cargo fmt -h`
    - `cargo fmt --help`
    - `cargo help fmt`

cargo-fmt will now print a help message and exit, instead of
unexpectedly formatting all .rs files recursively, even when
the current directory is not a Cargo project.
